### PR TITLE
Messages can be re-sent by clicking on history

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-keepattributes EnclosingMethod

--- a/app/src/main/java/in/dc297/mqttclpro/MQTTService.java
+++ b/app/src/main/java/in/dc297/mqttclpro/MQTTService.java
@@ -74,6 +74,9 @@ public class MQTTService extends Service implements MqttCallback
     /*    CONSTANTS                                                         */
     /************************************************************************/
 
+    public static final int DEFAULT_QOS = 0;
+    public static final boolean DEFAULT_RETAINED = false;
+
     // something unique to identify your app - used for stuff like accessing
     //   application preferences
     public static final String APP_ID = "in.dc297.mqttclpro";

--- a/app/src/main/java/in/dc297/mqttclpro/PublishedTopicActivity.java
+++ b/app/src/main/java/in/dc297/mqttclpro/PublishedTopicActivity.java
@@ -1,18 +1,28 @@
 package in.dc297.mqttclpro;
 
+import android.content.ComponentName;
 import android.content.Intent;
+import android.content.ServiceConnection;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.support.design.widget.FloatingActionButton;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ListView;
+import android.widget.Toast;
+import org.eclipse.paho.client.mqttv3.MqttTopic;
 
 public class PublishedTopicActivity extends AppCompatActivity {
+
+    private static final String TAG = "PubTopAct";
 
     private DBHelper db;
     private String topic;
@@ -44,8 +54,54 @@ public class PublishedTopicActivity extends AppCompatActivity {
         ListView pubTopsLV = (ListView)findViewById(R.id.pub_tops_lv);
         String[] from = new String[] { "message", "timestamp","display_topic"};
         int[] to = new int[]{R.id.mmessage_tv,R.id.mtimestamp_tv,R.id.mtopic_tv};
-        MessagesListAdapter pubmlvs = new MessagesListAdapter(getApplicationContext(),R.layout.messages_list_item,db.getMessages(topic,1),from,to,0);
+        final MessagesListAdapter pubmlvs = new MessagesListAdapter(getApplicationContext(),R.layout.messages_list_item,db.getMessages(topic,1),from,to,0);
         pubTopsLV.setAdapter(pubmlvs);
+
+        pubTopsLV.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+                                             @Override
+                                             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                                                 Log.d(TAG, "itemClicked");
+                                                 Cursor cursor = pubmlvs.getCursor();
+                                                 cursor.moveToPosition(i);
+                                                 final String topic = cursor.getString(4);
+                                                 final String message = cursor.getString(1);
+                                                 final int qos = MQTTService.DEFAULT_QOS;
+                                                 final boolean retained = MQTTService.DEFAULT_RETAINED;
+
+                                                 bindService(new Intent(getApplicationContext(), MQTTService.class), new ServiceConnection() {
+                                                     @Override
+                                                     public void onServiceConnected(ComponentName name, IBinder service) {
+                                                         MQTTService mqttService = ((MQTTService.LocalBinder<MQTTService>) service).getService();
+                                                         if(mqttService.getConnectionStatus().equals(MQTTService.MQTTConnectionStatus.CONNECTED)){
+                                                             try{
+                                                                 MqttTopic.validate(topic,false);
+                                                             }
+                                                             catch(IllegalArgumentException ila){
+                                                                 Toast.makeText(getApplicationContext(),"Invalid topic",Toast.LENGTH_SHORT).show();
+                                                                 return;
+                                                             }
+                                                             catch(IllegalStateException ise){
+                                                                 Toast.makeText(getApplicationContext(),"Invalid topic",Toast.LENGTH_SHORT).show();
+                                                                 return;
+                                                             }
+                                                             db.addTopic(topic,1,qos);
+                                                             long message_id = db.addMessage(topic,message,1,qos);
+
+                                                             mqttService.publishMessage(topic, message, Integer.toString(qos),message_id,retained);
+                                                         }
+                                                         else{
+                                                             Toast.makeText(getApplicationContext(),"Oops seems like we are not connected! Please wait for connection.",Toast.LENGTH_SHORT).show();
+                                                         }
+                                                         unbindService(this);
+                                                     }
+
+                                                     @Override
+                                                     public void onServiceDisconnected(ComponentName name) {
+                                                     }
+                                                 },0);
+                                                 Log.d(TAG, "Message " + message + " to topic " + topic + " clicked");
+                                             }
+                                         });
     }
 
     @Override

--- a/app/src/main/java/in/dc297/mqttclpro/SSL/SSLUtil.java
+++ b/app/src/main/java/in/dc297/mqttclpro/SSL/SSLUtil.java
@@ -7,8 +7,6 @@
  * Reference - https://gist.github.com/sharonbn/4104301"
  */
 package in.dc297.mqttclpro.SSL;
-import android.Manifest;
-import android.support.v4.content.ContextCompat;
 
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 ext{
 
     compileSdkVersion = 24
-    buildToolsVersion = '23.0.3'
+    buildToolsVersion = '25.0.2'
 
 
     serviceArchivesBaseName = 'org.eclipse.paho.android.service'


### PR DESCRIPTION
A previously published message can be re-sent by clicking on it in the
history view.  There is an outstanding issue with this whereby if a
message has not been previously published this session the sending will
fail due to no connection and the app will no longer be able to send
any messages.

Notes: I wouldn't accept this pull request as is as it currently breaks the connection of the app to the broker. Not sure why - not familiar enough with the code. If you could take a look and give me a pointer I'd appreciate it.

There are also changes in here that I had to make to get this to compile locally for me (I am compiling with Java 8 using the latest Android SDK - also removed a couple of spurious imports).